### PR TITLE
Fix UICollectionView issue

### DIFF
--- a/Pod/Classes/NSArray+LMIndexChangeSets.m
+++ b/Pod/Classes/NSArray+LMIndexChangeSets.m
@@ -14,24 +14,27 @@
         }
         return NO;
     }];
-    
+
+    NSMutableArray* previousAfterDeletion = [previous mutableCopy];
+    [previousAfterDeletion removeObjectsAtIndexes:deleted];
+
     NSIndexSet* inserted = [updated indexesOfObjectsPassingTest:^BOOL(id prev, NSUInteger idx, BOOL *stop) {
-        if (previous == nil || [previous indexOfObjectPassingTest:^BOOL(id curr, NSUInteger idx, BOOL *stop) {
+        if (previousAfterDeletion == nil || [previousAfterDeletion indexOfObjectPassingTest:^BOOL(id curr, NSUInteger idx, BOOL *stop) {
             return (comparator(curr, prev) == NSOrderedSame);
         }] == NSNotFound) {
             return YES;
         }
         return NO;
     }];
-    
+
     NSMutableDictionary* moved = [NSMutableDictionary dictionary];
     NSMutableIndexSet* unmoved = [NSMutableIndexSet indexSet];
-    [previous enumerateObjectsUsingBlock:^(id prev, NSUInteger prevIndex, BOOL *stop) {
+    [previousAfterDeletion enumerateObjectsUsingBlock:^(id prev, NSUInteger prevIndex, BOOL *stop) {
         if (![deleted containsIndex:prevIndex]) {
             NSUInteger currIndex = [updated indexOfObjectPassingTest:^BOOL(id curr, NSUInteger idx, BOOL *stop) {
                 return (comparator(curr, prev) == NSOrderedSame);
             }];
-            
+
             if (currIndex != prevIndex && ![[moved allValues] containsObject:@(currIndex)]) {
                 moved[@(prevIndex)] = @(currIndex);
             }
@@ -40,14 +43,14 @@
             }
         }
     }];
-    
+
     NSDictionary* indexChangeSets = @{
         @"deleted"  : deleted   ? deleted  : [NSIndexSet indexSet],
         @"inserted" : inserted  ? inserted : [NSIndexSet indexSet],
         @"moved"    : moved,
         @"unmoved"  : unmoved
     };
-    
+
     return indexChangeSets;
 }
 

--- a/Pod/Classes/NSArray+LMIndexChangeSets.m
+++ b/Pod/Classes/NSArray+LMIndexChangeSets.m
@@ -6,52 +6,62 @@
                                    previousList:(NSArray*)previous
                              identityComparator:(NSComparisonResult (^)(id a, id b))comparator
 {
-    NSIndexSet* deleted = [previous indexesOfObjectsPassingTest:^BOOL(id prev, NSUInteger idx, BOOL *stop) {
-        if (updated == nil || [updated indexOfObjectPassingTest:^BOOL(id curr, NSUInteger idx, BOOL *stop) {
-            return (comparator(curr, prev) == NSOrderedSame);
-        }] == NSNotFound) {
-            return YES;
-        }
-        return NO;
-    }];
-
-    NSMutableArray* previousAfterDeletion = [previous mutableCopy];
-    [previousAfterDeletion removeObjectsAtIndexes:deleted];
-
-    NSIndexSet* inserted = [updated indexesOfObjectsPassingTest:^BOOL(id prev, NSUInteger idx, BOOL *stop) {
-        if (previousAfterDeletion == nil || [previousAfterDeletion indexOfObjectPassingTest:^BOOL(id curr, NSUInteger idx, BOOL *stop) {
-            return (comparator(curr, prev) == NSOrderedSame);
-        }] == NSNotFound) {
-            return YES;
-        }
-        return NO;
-    }];
-
-    NSMutableDictionary* moved = [NSMutableDictionary dictionary];
-    NSMutableIndexSet* unmoved = [NSMutableIndexSet indexSet];
-    [previousAfterDeletion enumerateObjectsUsingBlock:^(id prev, NSUInteger prevIndex, BOOL *stop) {
-        if (![deleted containsIndex:prevIndex]) {
-            NSUInteger currIndex = [updated indexOfObjectPassingTest:^BOOL(id curr, NSUInteger idx, BOOL *stop) {
-                return (comparator(curr, prev) == NSOrderedSame);
-            }];
-
-            if (currIndex != prevIndex && ![[moved allValues] containsObject:@(currIndex)]) {
-                moved[@(prevIndex)] = @(currIndex);
-            }
-            else {
-                [unmoved addIndex:currIndex];
-            }
-        }
-    }];
-
-    NSDictionary* indexChangeSets = @{
-        @"deleted"  : deleted   ? deleted  : [NSIndexSet indexSet],
-        @"inserted" : inserted  ? inserted : [NSIndexSet indexSet],
-        @"moved"    : moved,
-        @"unmoved"  : unmoved
-    };
-
-    return indexChangeSets;
+  NSIndexSet* deleted = [previous indexesOfObjectsPassingTest:^BOOL(id prev, NSUInteger idx, BOOL *stop) {
+    if (updated == nil || [updated indexOfObjectPassingTest:^BOOL(id curr, NSUInteger idx, BOOL *stop) {
+      return (comparator(curr, prev) == NSOrderedSame);
+    }] == NSNotFound) {
+      return YES;
+    }
+    return NO;
+  }];
+  
+  NSMutableArray* previousAfterDeletion = [previous mutableCopy];
+  [previousAfterDeletion removeObjectsAtIndexes:deleted];
+  
+  NSIndexSet* inserted = [updated indexesOfObjectsPassingTest:^BOOL(id prev, NSUInteger idx, BOOL *stop) {
+    if (previous == nil || [previous indexOfObjectPassingTest:^BOOL(id curr, NSUInteger idx, BOOL *stop) {
+      return (comparator(curr, prev) == NSOrderedSame);
+    }] == NSNotFound) {
+      return YES;
+    }
+    return NO;
+  }];
+  
+  NSMutableArray* updatedBeforeInsertion = [updated mutableCopy];
+  [updatedBeforeInsertion removeObjectsAtIndexes:inserted];
+  
+  NSMutableDictionary* moved = [NSMutableDictionary dictionary];
+  NSMutableIndexSet* unmoved = [NSMutableIndexSet indexSet];
+  [previous enumerateObjectsUsingBlock:^(id prev, NSUInteger prevIndex, BOOL *stop) {
+    if (![deleted containsIndex:prevIndex]) {
+      NSUInteger currIndex = [updated indexOfObjectPassingTest:^BOOL(id curr, NSUInteger idx, BOOL *stop) {
+        return (comparator(curr, prev) == NSOrderedSame);
+      }];
+      
+      int prevAfterDeleteIndex = (int)[previousAfterDeletion indexOfObjectPassingTest:^BOOL(id curr, NSUInteger idx, BOOL *stop) {
+        return (comparator(curr, prev) == NSOrderedSame);
+      }];
+      int updateBeforeInsertIndex = (int)[updatedBeforeInsertion indexOfObjectPassingTest:^BOOL(id curr, NSUInteger idx, BOOL *stop) {
+        return (comparator(curr, updated[currIndex]) == NSOrderedSame);
+      }];
+      
+      if (updateBeforeInsertIndex != prevAfterDeleteIndex && ![[moved allValues] containsObject:@(currIndex)]) {
+        moved[@(prevIndex)] = @(currIndex);
+      }
+      else {
+        [unmoved addIndex:currIndex];
+      }
+    }
+  }];
+  
+  NSDictionary* indexChangeSets = @{
+                                    @"deleted"  : deleted   ? deleted  : [NSIndexSet indexSet],
+                                    @"inserted" : inserted  ? inserted : [NSIndexSet indexSet],
+                                    @"moved"    : moved,
+                                    @"unmoved"  : unmoved
+                                    };
+  
+  return indexChangeSets;
 }
 
 @end


### PR DESCRIPTION
Fixed a bug where insert/delete caused a move to happen as well which resulted in a crash.
e.g.
old: {a,b}
new: {b}

delete 0
move 1 -> 0
crash: invalid index 1
